### PR TITLE
feat: Add middleware for logging and secure headers

### DIFF
--- a/app/routes/_middleware.ts
+++ b/app/routes/_middleware.ts
@@ -1,5 +1,16 @@
 import { createRoute } from 'honox/factory'
-import { secureHeaders } from 'hono/secure-headers'
+import { NONCE, secureHeaders } from 'hono/secure-headers'
 import { logger } from 'hono/logger'
 
-export default createRoute(logger(), secureHeaders())
+export default createRoute(
+  logger(),
+  secureHeaders({
+    strictTransportSecurity: 'max-age=63072000; includeSubDomains; preload',
+    contentSecurityPolicy: import.meta.env.PROD
+      ? {
+          scriptSrc: [NONCE],
+          defaultSrc: ["'self'"],
+        }
+      : undefined,
+  }),
+)

--- a/app/routes/_middleware.ts
+++ b/app/routes/_middleware.ts
@@ -1,0 +1,5 @@
+import { createRoute } from 'honox/factory'
+import { secureHeaders } from 'hono/secure-headers'
+import { logger } from 'hono/logger'
+
+export default createRoute(logger(), secureHeaders())

--- a/app/routes/_middleware.ts
+++ b/app/routes/_middleware.ts
@@ -13,4 +13,10 @@ export default createRoute(
         }
       : undefined,
   }),
+  async c => {
+    return c.res.headers.append(
+      'Permissions-Policy',
+      'accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), cross-origin-isolated=(), display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=(), execution-while-out-of-viewport=(), fullscreen=(), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), navigation-override=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=()',
+    )
+  },
 )


### PR DESCRIPTION
The code changes add middleware for logging and secure headers to the routes. This improves the security and logging capabilities of the application.

addSecurityHeaders: https://68d76633.gensya-akuyaku-source.pages.dev/
https://securityheaders.com/?q=https%3A%2F%2F68d76633.gensya-akuyaku-source.pages.dev%2F

settingCSP&strict transport security: https://0b0b293b.gensya-akuyaku-source.pages.dev/
https://securityheaders.com/?q=https%3A%2F%2F0b0b293b.gensya-akuyaku-source.pages.dev%2F

addPermissionsPolicy: https://af7d300e.gensya-akuyaku-source.pages.dev/
https://securityheaders.com/?q=https%3A%2F%2Faf7d300e.gensya-akuyaku-source.pages.dev%2F